### PR TITLE
add yamc::fair::(recursive_)timed_mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Note: [`std::mutex`'s default constructor][mutex_ctor] is constexpr, but `yamc::
 - `yamc::checked::recursive_timed_mutex`: requirements debugging, recursive, support timeout
 - `yamc::fair::mutex`: fairness, non-recursive
 - `yamc::fair::recursive_mutex`: fairness, recursive
+- `yamc::fair::timed_mutex`: fairness, non-recursive, support timeout
+- `yamc::fair::recursive_timed_mutex`: fairness, recursive, support timeout
 - `yamc::alternate::recursive_mutex`: recursive
 - `yamc::alternate::timed_mutex`: non-recursive, support timeout
 - `yamc::alternate::recursive_timed_mutex`: recursive, support timeout

--- a/include/fair_mutex.hpp
+++ b/include/fair_mutex.hpp
@@ -36,6 +36,11 @@ namespace yamc {
 
 /*
  * fairness (FIFO locking) mutex
+ *
+ * - yamc::fair::mutex
+ * - yamc::fair::recursive_mutex
+ * - yamc::fair::timed_mutex
+ * - yamc::fair::recursive_timed_mutex
  */
 namespace fair {
 
@@ -133,10 +138,9 @@ public:
   void unlock()
   {
     std::lock_guard<decltype(mtx_)> lk(mtx_);
-    assert(0 < ncount_);
+    assert(0 < ncount_ && owner_ == std::this_thread::get_id());
     if (--ncount_ == 0) {
       ++curr_;
-      assert(owner_ == std::this_thread::get_id());
       owner_ = std::thread::id();
       cv_.notify_all();
     }
@@ -144,7 +148,9 @@ public:
 };
 
 
-class timed_mutex {
+namespace detail {
+
+class timed_mutex_base {
   struct node {
     node* next;
     node* prev;
@@ -152,9 +158,12 @@ class timed_mutex {
 
   node queue_;   // q.next = front(), q.prev = back()
   node locked_;  // placeholder node of 'locked' state
+
+protected:
   std::condition_variable cv_;
   std::mutex mtx_;
 
+private:
   bool wq_empty()
   {
     return queue_.next == &queue_;
@@ -188,10 +197,44 @@ class timed_mutex {
     queue_.next = front->next->prev = p;
   }
 
-  template<typename Clock, typename Duration>
-  bool do_try_lockwait(const std::chrono::time_point<Clock, Duration>& tp)
+protected:
+  timed_mutex_base()
+    : queue_{&queue_, &queue_} {}
+  ~timed_mutex_base() = default;
+
+  void impl_lock(std::unique_lock<std::mutex>& lk)
   {
-    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    if (!wq_empty()) {
+      node request;
+      wq_push_back(&request);
+      while (queue_.next != &request) {
+        cv_.wait(lk);
+      }
+      wq_replace_front(&locked_);
+    } else {
+      wq_push_back(&locked_);
+    }
+  }
+
+  bool impl_try_lock()
+  {
+    if (!wq_empty()) {
+      return false;
+    }
+    wq_push_back(&locked_);
+    return true;
+  }
+
+  void impl_unlock()
+  {
+    assert(queue_.next == &locked_);
+    wq_pop_front();
+    cv_.notify_all();
+  }
+
+  template<typename Clock, typename Duration>
+  bool impl_try_lockwait(std::unique_lock<std::mutex>& lk, const std::chrono::time_point<Clock, Duration>& tp)
+  {
     if (!wq_empty()) {
       node request;
       wq_push_back(&request);
@@ -209,10 +252,16 @@ class timed_mutex {
     }
     return true;
   }
+};
+
+} // namespace detail
+
+
+class timed_mutex : private detail::timed_mutex_base {
+  using base = detail::timed_mutex_base;
 
 public:
-  timed_mutex()
-    : queue_{&queue_, &queue_} {}
+  timed_mutex() = default;
   ~timed_mutex() = default;
 
   timed_mutex(const timed_mutex&) = delete;
@@ -221,47 +270,113 @@ public:
   void lock()
   {
     std::unique_lock<decltype(mtx_)> lk(mtx_);
-    if (!wq_empty()) {
-      node request;
-      wq_push_back(&request);
-      while (queue_.next != &request) {
-        cv_.wait(lk);
-      }
-      wq_replace_front(&locked_);
-    } else {
-      wq_push_back(&locked_);
-    }
+    base::impl_lock(lk);
   }
 
   bool try_lock()
   {
     std::lock_guard<decltype(mtx_)> lk(mtx_);
-    if (!wq_empty()) {
-      return false;
+    return base::impl_try_lock();
+  }
+
+  void unlock()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    base::impl_unlock();
+  }
+
+  template<typename Rep, typename Period>
+  bool try_lock_for(const std::chrono::duration<Rep, Period>& duration)
+  {
+    const auto tp = std::chrono::steady_clock::now() + duration;
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lockwait(lk, tp);
+  }
+
+  template<typename Clock, typename Duration>
+  bool try_lock_until(const std::chrono::time_point<Clock, Duration>& tp)
+  {
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lockwait(lk, tp);
+  }
+};
+
+
+class recursive_timed_mutex : private detail::timed_mutex_base {
+  using base = detail::timed_mutex_base;
+
+  std::size_t ncount_ = 0;
+  std::thread::id owner_ = {};
+
+public:
+  recursive_timed_mutex() = default;
+  ~recursive_timed_mutex() = default;
+
+  recursive_timed_mutex(const recursive_timed_mutex&) = delete;
+  recursive_timed_mutex& operator=(const recursive_timed_mutex&) = delete;
+
+  void lock()
+  {
+    const auto tid = std::this_thread::get_id();
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    if (owner_ == tid) {
+      assert(0 < ncount_);
+      ++ncount_;
+    } else {
+      base::impl_lock(lk);
+      ncount_ = 1;
+      owner_ = tid;
     }
-    wq_push_back(&locked_);
+  }
+
+  bool try_lock()
+  {
+    const auto tid = std::this_thread::get_id();
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    if (owner_ == tid) {
+      assert(0 < ncount_);
+      ++ncount_;
+      return true;
+    }
+    if (!base::impl_try_lock())
+      return false;
+    ncount_ = 1;
+    owner_ = tid;
     return true;
   }
 
   void unlock()
   {
     std::lock_guard<decltype(mtx_)> lk(mtx_);
-    assert(queue_.next == &locked_);
-    wq_pop_front();
-    cv_.notify_all();
+    assert(0 < ncount_ && owner_ == std::this_thread::get_id());
+    if (--ncount_ == 0) {
+      base::impl_unlock();
+      owner_ = std::thread::id();
+    }
   }
 
   template<typename Rep, typename Period>
   bool try_lock_for(const std::chrono::duration<Rep, Period>& duration)
   {
-    const auto tp = std::chrono::system_clock::now() + duration;
-    return do_try_lockwait(tp);
+    const auto tp = std::chrono::steady_clock::now() + duration;
+    return try_lock_until(tp);  // delegate
   }
 
   template<typename Clock, typename Duration>
   bool try_lock_until(const std::chrono::time_point<Clock, Duration>& tp)
   {
-    return do_try_lockwait(tp);
+    const auto tid = std::this_thread::get_id();
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    if (owner_ == tid) {
+      assert(0 < ncount_);
+      ++ncount_;
+      return true;
+    }
+    if (!base::impl_try_lockwait(lk, tp))
+      return false;
+    ncount_ = 1;
+    owner_ = tid;
+    return true;
   }
 };
 

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -25,7 +25,8 @@ using NormalMutexTypes = ::testing::Types<
   yamc::spin_weak::mutex,
   yamc::spin_ttas::mutex,
   yamc::checked::mutex,
-  yamc::fair::mutex
+  yamc::fair::mutex,
+  yamc::fair::timed_mutex
 >;
 
 template <typename Mutex>
@@ -185,6 +186,7 @@ TYPED_TEST(RecursiveMutexTest, TryLockFail)
 using TimedMutexTypes = ::testing::Types<
   yamc::checked::timed_mutex,
   yamc::checked::recursive_timed_mutex,
+  yamc::fair::timed_mutex,
   yamc::alternate::timed_mutex,
   yamc::alternate::recursive_timed_mutex
 >;

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -92,6 +92,7 @@ using RecursiveMutexTypes = ::testing::Types<
   yamc::checked::recursive_mutex,
   yamc::checked::recursive_timed_mutex,
   yamc::fair::recursive_mutex,
+  yamc::fair::recursive_timed_mutex,
   yamc::alternate::recursive_mutex,
   yamc::alternate::recursive_timed_mutex
 >;
@@ -187,6 +188,7 @@ using TimedMutexTypes = ::testing::Types<
   yamc::checked::timed_mutex,
   yamc::checked::recursive_timed_mutex,
   yamc::fair::timed_mutex,
+  yamc::fair::recursive_timed_mutex,
   yamc::alternate::timed_mutex,
   yamc::alternate::recursive_timed_mutex
 >;

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -81,6 +81,7 @@ int main()
   test_requirements<yamc::fair::mutex>();
   test_requirements<yamc::fair::recursive_mutex>();
   test_requirements_timed<yamc::fair::timed_mutex>();
+  test_requirements_timed<yamc::fair::recursive_timed_mutex>();
   test_requirements<yamc::alternate::recursive_mutex>();
   test_requirements_timed<yamc::alternate::timed_mutex>();
   test_requirements_timed<yamc::alternate::recursive_timed_mutex>();

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -80,6 +80,7 @@ int main()
   test_requirements_timed<yamc::checked::recursive_timed_mutex>();
   test_requirements<yamc::fair::mutex>();
   test_requirements<yamc::fair::recursive_mutex>();
+  test_requirements_timed<yamc::fair::timed_mutex>();
   test_requirements<yamc::alternate::recursive_mutex>();
   test_requirements_timed<yamc::alternate::timed_mutex>();
   test_requirements_timed<yamc::alternate::recursive_timed_mutex>();

--- a/tests/dump_sizeof.cpp
+++ b/tests/dump_sizeof.cpp
@@ -33,6 +33,7 @@ int main()
   DUMP(yamc::checked::recursive_timed_mutex);
   DUMP(yamc::fair::mutex);
   DUMP(yamc::fair::recursive_mutex);
+  DUMP(yamc::fair::timed_mutex);
   DUMP(yamc::alternate::recursive_mutex);
   DUMP(yamc::alternate::timed_mutex);
   DUMP(yamc::alternate::recursive_timed_mutex);

--- a/tests/fairness_test.cpp
+++ b/tests/fairness_test.cpp
@@ -33,7 +33,8 @@ std::mutex g_guard;
 using FairMutexTypes = ::testing::Types<
   yamc::fair::mutex,
   yamc::fair::timed_mutex,
-  yamc::fair::recursive_mutex
+  yamc::fair::recursive_mutex,
+  yamc::fair::recursive_timed_mutex
 >;
 
 template <typename Mutex>
@@ -98,7 +99,8 @@ TYPED_TEST(FairMutexTest, FifoSched)
 
 
 using FairTimedMutexTypes = ::testing::Types<
-  yamc::fair::timed_mutex
+  yamc::fair::timed_mutex,
+  yamc::fair::recursive_timed_mutex
 >;
 
 template <typename Mutex>

--- a/tests/fairness_test.cpp
+++ b/tests/fairness_test.cpp
@@ -30,6 +30,7 @@ std::mutex g_guard;
 
 using FairMutexTypes = ::testing::Types<
   yamc::fair::mutex,
+  yamc::fair::timed_mutex,
   yamc::fair::recursive_mutex
 >;
 

--- a/tests/fairness_test.cpp
+++ b/tests/fairness_test.cpp
@@ -10,12 +10,6 @@
 #include "yamc_testutil.hpp"
 
 
-#define TEST_TICKS std::chrono::milliseconds(200)
-
-#define EXPECT_STEP(n_) \
-  { EXPECT_EQ(n_, ++step); std::this_thread::sleep_for(TEST_TICKS); }
-
-
 #if 0
 namespace {
 std::mutex g_guard;
@@ -26,6 +20,14 @@ std::mutex g_guard;
 #else
 #define TRACE(msg_)
 #endif
+
+
+#define TEST_EXPECT_TIMEOUT std::chrono::milliseconds(10)
+#define TEST_NOT_TIMEOUT std::chrono::minutes(3)
+#define TEST_TICKS std::chrono::milliseconds(200)
+
+#define EXPECT_STEP(n_) \
+  { TRACE("STEP"#n_); EXPECT_EQ(n_, ++step); std::this_thread::sleep_for(TEST_TICKS); }
 
 
 using FairMutexTypes = ::testing::Types<
@@ -41,11 +43,11 @@ TYPED_TEST_CASE(FairMutexTest, FairMutexTypes);
 
 // FIFO scheduling
 //
-// T0: T=1=a=a=====w=4=U........
-//         |  \   /    |
-// T1: ....w.2.a.a.l---L=5=U....
-//         |   |  \        |
-// T2: ....w.t.w.3.a.l-----L=6=U
+// T0: T=1=a=a=====w=4=U.......L=7=U
+//         |  \   /    |       |
+// T1: ....w.2.a.a.l---L=5=U........
+//         |   |  \        |   |
+// T2: ....w.t.w.3.a.l-----L=6=U....
 //
 //   l/L=lock(request/acquired), U=unlock()
 //   T=try_lock(true), t=try_lock(false)
@@ -67,6 +69,9 @@ TYPED_TEST(FairMutexTest, FifoSched)
       ph.await();     // p3
       EXPECT_STEP(4)
       mtx.unlock();
+      mtx.lock();
+      EXPECT_STEP(7)
+      mtx.unlock();
       break;
     case 1:
       ph.await();     // p1
@@ -83,6 +88,123 @@ TYPED_TEST(FairMutexTest, FifoSched)
       EXPECT_STEP(3)
       ph.advance(1);  // p3
       mtx.lock();
+      EXPECT_STEP(6)
+      mtx.unlock();
+      break;
+    }
+  });
+  ASSERT_LE(TEST_TICKS * step, sw.elapsed());
+}
+
+
+using FairTimedMutexTypes = ::testing::Types<
+  yamc::fair::timed_mutex
+>;
+
+template <typename Mutex>
+struct FairTimedMutexTest : ::testing::Test {};
+
+TYPED_TEST_CASE(FairTimedMutexTest, FairTimedMutexTypes);
+
+// FIFO scheduling with try_lock_for()
+//
+// T0: T=1=a=====a=====w=4=U........
+//         |      \   /    |
+// T1: ....w.......w.a.t---T=5=U....
+//         |       |  \        |
+// T2: ....w.t-2-*.w.3.a.t-----T=6=U
+//
+//   t/T=try_lock_for(request/acquired)
+//   U=unlock(), *=timeout
+//   a=phase advance, w=phase await
+//
+TYPED_TEST(FairTimedMutexTest, FifoTryLockFor)
+{
+  yamc::test::phaser phaser(3);
+  int step = 0;
+  TypeParam mtx;
+  yamc::test::stopwatch<> sw;
+  yamc::test::task_runner(3, [&](std::size_t id) {
+    auto ph = phaser.get(id);
+    switch (id) {
+    case 0:
+      EXPECT_TRUE(mtx.try_lock_for(TEST_NOT_TIMEOUT));
+      EXPECT_STEP(1)
+      ph.advance(2);  // p1-2
+      ph.await();     // p3
+      EXPECT_STEP(4)
+      mtx.unlock();
+      break;
+    case 1:
+      ph.await();     // p1
+      ph.await();     // p2
+      ph.advance(1);  // p3
+      EXPECT_TRUE(mtx.try_lock_for(TEST_NOT_TIMEOUT));
+      EXPECT_STEP(5)
+      mtx.unlock();
+      break;
+    case 2:
+      ph.await();     // p1
+      EXPECT_EQ(2, ++step);
+      EXPECT_FALSE(mtx.try_lock_for(TEST_TICKS));
+      ph.await();     // p2
+      EXPECT_STEP(3)
+      ph.advance(1);  // p3
+      EXPECT_TRUE(mtx.try_lock_for(TEST_NOT_TIMEOUT));
+      EXPECT_STEP(6)
+      mtx.unlock();
+      break;
+    }
+  });
+  ASSERT_LE(TEST_TICKS * step, sw.elapsed());
+}
+
+// FIFO scheduling with try_lock_until()
+//
+// T0: T=1=a=====a=====w=4=U........
+//         |      \   /    |
+// T1: ....w.......w.a.t---L=5=U....
+//         |       |  \        |
+// T2: ....w.t-2-*.w.3.a.t-----L=6=U
+//
+//   t/T=try_lock_until(request/acquired)
+//   U=unlock(), *=timeout
+//   a=phase advance, w=phase await
+//
+TYPED_TEST(FairTimedMutexTest, FifoTryLockUntil)
+{
+  yamc::test::phaser phaser(3);
+  int step = 0;
+  TypeParam mtx;
+  using Clock = std::chrono::steady_clock;
+  yamc::test::stopwatch<> sw;
+  yamc::test::task_runner(3, [&](std::size_t id) {
+    auto ph = phaser.get(id);
+    switch (id) {
+    case 0:
+      EXPECT_TRUE(mtx.try_lock_until(Clock::now() + TEST_NOT_TIMEOUT));
+      EXPECT_STEP(1)
+      ph.advance(2);  // p1-2
+      ph.await();     // p3
+      EXPECT_STEP(4)
+      mtx.unlock();
+      break;
+    case 1:
+      ph.await();     // p1
+      ph.await();     // p2
+      ph.advance(1);  // p3
+      EXPECT_TRUE(mtx.try_lock_until(Clock::now() + TEST_NOT_TIMEOUT));
+      EXPECT_STEP(5)
+      mtx.unlock();
+      break;
+    case 2:
+      ph.await();     // p1
+      EXPECT_EQ(2, ++step);
+      EXPECT_FALSE(mtx.try_lock_until(Clock::now() + TEST_TICKS));
+      ph.await();     // p2
+      EXPECT_STEP(3)
+      ph.advance(1);  // p3
+      EXPECT_TRUE(mtx.try_lock_until(Clock::now() + TEST_NOT_TIMEOUT));
       EXPECT_STEP(6)
       mtx.unlock();
       break;


### PR DESCRIPTION
add `yamc::fair::{timed_mutex, recursive_timed_mutex}`. issue #7 

- [X] implement `yamc::fair::timed_mutex`
- [x] implement `yamc::fair::recursive_timed_mutex`
- [X] add test case of fairness locking with timeout by `try_lock_{for,until}`