### PR TITLE
add yamc::fair::shared_(timed_)mutex

### DIFF
--- a/include/fair_shared_mutex.hpp
+++ b/include/fair_shared_mutex.hpp
@@ -172,11 +172,12 @@ protected:
             // Phase-marging: If previous node represents current shared-lock,
             // mark subsequent 'waiting' shared-lock nodes as 'lockable'.
             //
-            node* p = queue_.next;
+            node* p = request.next;
             while (p != &queue_ && (p->status & node_status_mask) == 1) {
               p->status |= 2;
               p = p->next;
             }
+            cv_.notify_all();
           }
           wq_erase(&request);
           return false;

--- a/include/fair_shared_mutex.hpp
+++ b/include/fair_shared_mutex.hpp
@@ -1,0 +1,376 @@
+/*
+ * fair_shared_mutex.hpp
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 yohhoy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef YAMC_FAIR_SHARED_MUTEX_HPP_
+#define YAMC_FAIR_SHARED_MUTEX_HPP_
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+
+namespace yamc {
+
+/*
+ * phase-fairness (FIFO locking) shared mutex
+ *
+ * - yamc::fair::shared_mutex
+ * - yamc::fair::shared_timd_mutex
+ */
+namespace fair {
+
+namespace detail {
+
+class shared_mutex_base {
+protected:
+  const static std::size_t node_status_mask = 3;
+  const static std::size_t node_nthread_inc = (1U << 2);
+
+  struct node {
+    std::size_t status;
+    // bitmask:
+    //   (LSB)0: 0=exclusive-lock / 1=shared-lock
+    //        1: 0=waiting / 1=lockable(-ing)
+    //   MSB..2: number of locking thread (locked_ member only)
+    node* next;
+    node* prev;
+  };
+
+  node queue_;   // q.next = front(), q.prev = back()
+  node locked_;  // placeholder node of 'locked' state
+  std::condition_variable cv_;
+  std::mutex mtx_;
+
+private:
+  bool wq_empty()
+  {
+    return queue_.next == &queue_;
+  }
+
+  void wq_push_front(node* p)
+  {
+    node* next = queue_.next;
+    next->prev = queue_.next = p;
+    p->next = next;
+    p->prev = &queue_;
+  }
+
+  void wq_push_back(node* p)
+  {
+    node* back = queue_.prev;
+    back->next = queue_.prev = p;
+    p->next = &queue_;
+    p->prev = back;
+  }
+
+  void wq_erase(node* p)
+  {
+    p->next->prev = p->prev;
+    p->prev->next = p->next;
+  }
+
+  bool wq_shared_lockable()
+  {
+    return wq_empty() || (queue_.prev->status & node_status_mask) == 3;
+  }
+
+  void wq_push_locknode(int mode)
+  {
+    if (queue_.next != &locked_) {
+      locked_.status = mode | 2;
+      wq_push_front(&locked_);
+    }
+    assert((locked_.status & node_status_mask) == (mode | 2));
+    locked_.status += node_nthread_inc;
+  }
+
+  void wq_pop_locknode()
+  {
+    assert(queue_.next == &locked_);
+    wq_erase(&locked_);
+    locked_.status = 0;
+    locked_.next = locked_.prev = nullptr;
+  }
+
+protected:
+  shared_mutex_base()
+    : queue_{0, &queue_, &queue_} {}
+  ~shared_mutex_base() = default;
+
+  void impl_lock(std::unique_lock<std::mutex>& lk)
+  {
+    if (!wq_empty()) {
+      node request = {0, 0, 0};  // exclusive-lock
+      wq_push_back(&request);
+      while (queue_.next != &request) {
+        cv_.wait(lk);
+      }
+      wq_erase(&request);
+    }
+    wq_push_locknode(0);
+  }
+
+  bool impl_try_lock()
+  {
+    if (!wq_empty()) {
+      return false;
+    }
+    wq_push_locknode(0);
+    return true;
+  }
+
+  void impl_unlock()
+  {
+    assert(queue_.next == &locked_ && (locked_.status & node_status_mask) == 2);
+    wq_pop_locknode();
+    if (!wq_empty()) {
+      // mark subsequent 'waiting' shared-lock nodes as 'lockable'
+      node* p = queue_.next;
+      while (p != &queue_ && (p->status & node_status_mask) == 1) {
+        p->status |= 2;
+        p = p->next;
+      }
+    }
+    cv_.notify_all();
+  }
+
+  template<typename Clock, typename Duration>
+  bool impl_try_lockwait(std::unique_lock<std::mutex>& lk, const std::chrono::time_point<Clock, Duration>& tp)
+  {
+    if (!wq_empty()) {
+      node request = {0, 0, 0};  // exclusive-lock
+      wq_push_back(&request);
+      while (queue_.next != &request) {
+        if (cv_.wait_until(lk, tp) == std::cv_status::timeout) {
+          if (queue_.next == &request)  // re-check predicate
+            break;
+          if (request.prev == &locked_ && (locked_.status & node_status_mask) == 3) {
+            //
+            // Phase-marging: If previous node represents current shared-lock,
+            // mark subsequent 'waiting' shared-lock nodes as 'lockable'.
+            //
+            node* p = queue_.next;
+            while (p != &queue_ && (p->status & node_status_mask) == 1) {
+              p->status |= 2;
+              p = p->next;
+            }
+          }
+          wq_erase(&request);
+          return false;
+        }
+      }
+      wq_erase(&request);
+    }
+    wq_push_locknode(0);
+    return true;
+  }
+
+  void impl_lock_shared(std::unique_lock<std::mutex>& lk)
+  {
+    if (!wq_shared_lockable()) {
+      node request = {1, 0, 0};  // shared-lock
+      wq_push_back(&request);
+      while (request.status != 3) {
+        cv_.wait(lk);
+      }
+      wq_erase(&request);
+    }
+    wq_push_locknode(1);
+  }
+
+  bool impl_try_lock_shared()
+  {
+    if (!wq_shared_lockable()) {
+      return false;
+    }
+    wq_push_locknode(1);
+    return true;
+  }
+
+  void impl_unlock_shared()
+  {
+    assert(queue_.next == &locked_ && (locked_.status & node_status_mask) == 3);
+    locked_.status -= node_nthread_inc;
+    if (locked_.status < node_nthread_inc) {
+      // all current shared-locks was unlocked
+      wq_pop_locknode();
+      cv_.notify_all();
+    }
+  }
+
+  template<typename Clock, typename Duration>
+  bool impl_try_lockwait_shared(std::unique_lock<std::mutex>& lk, const std::chrono::time_point<Clock, Duration>& tp)
+  {
+    if (!wq_shared_lockable()) {
+      node request = {1, 0, 0};  // shared-lock
+      wq_push_back(&request);
+      while (request.status != 3) {
+        if (cv_.wait_until(lk, tp) == std::cv_status::timeout) {
+          if (request.status == 3)  // re-check predicate
+            break;
+          wq_erase(&request);
+          return false;
+        }
+      }
+      wq_erase(&request);
+    }
+    wq_push_locknode(1);
+    return true;
+  }
+};
+
+} // namespace detail
+
+
+class shared_mutex : private detail::shared_mutex_base {
+  using base = detail::shared_mutex_base;
+
+public:
+  shared_mutex() = default;
+  ~shared_mutex() = default;
+
+  shared_mutex(const shared_mutex&) = delete;
+  shared_mutex& operator=(const shared_mutex&) = delete;
+
+  void lock()
+  {
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    base::impl_lock(lk);
+  }
+
+  bool try_lock()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lock();
+  }
+
+  void unlock()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    base::impl_unlock();
+  }
+
+  void lock_shared()
+  {
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    base::impl_lock_shared(lk);
+  }
+
+  bool try_lock_shared()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lock_shared();
+  }
+
+  void unlock_shared()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    base::impl_unlock_shared();
+  }
+};
+
+
+class shared_timed_mutex : private detail::shared_mutex_base {
+  using base = detail::shared_mutex_base;
+
+public:
+  shared_timed_mutex() = default;
+  ~shared_timed_mutex() = default;
+
+  shared_timed_mutex(const shared_timed_mutex&) = delete;
+  shared_timed_mutex& operator=(const shared_timed_mutex&) = delete;
+
+  void lock()
+  {
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    base::impl_lock(lk);
+  }
+
+  bool try_lock()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lock();
+  }
+
+  void unlock()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    base::impl_unlock();
+  }
+
+  template<typename Rep, typename Period>
+  bool try_lock_for(const std::chrono::duration<Rep, Period>& duration)
+  {
+    const auto tp = std::chrono::steady_clock::now() + duration;
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lockwait(lk, tp);
+  }
+
+  template<typename Clock, typename Duration>
+  bool try_lock_until(const std::chrono::time_point<Clock, Duration>& tp)
+  {
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lockwait(lk, tp);
+  }
+
+  void lock_shared()
+  {
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    base::impl_lock_shared(lk);
+  }
+
+  bool try_lock_shared()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lock_shared();
+  }
+
+  void unlock_shared()
+  {
+    std::lock_guard<decltype(mtx_)> lk(mtx_);
+    base::impl_unlock_shared();
+  }
+
+  template<typename Rep, typename Period>
+  bool try_lock_shared_for(const std::chrono::duration<Rep, Period>& duration)
+  {
+    const auto tp = std::chrono::steady_clock::now() + duration;
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lockwait_shared(lk, tp);
+  }
+
+  template<typename Clock, typename Duration>
+  bool try_lock_shared_until(const std::chrono::time_point<Clock, Duration>& tp)
+  {
+    std::unique_lock<decltype(mtx_)> lk(mtx_);
+    return base::impl_try_lockwait_shared(lk, tp);
+  }
+};
+
+} // namespace fair
+} // namespace yamc
+
+#endif

--- a/include/fair_shared_mutex.hpp
+++ b/include/fair_shared_mutex.hpp
@@ -97,7 +97,7 @@ private:
     return wq_empty() || (queue_.prev->status & node_status_mask) == 3;
   }
 
-  void wq_push_locknode(int mode)
+  void wq_push_locknode(unsigned mode)
   {
     if (queue_.next != &locked_) {
       locked_.status = mode | 2;

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -10,6 +10,7 @@
 #include "ttas_spin_mutex.hpp"
 #include "checked_mutex.hpp"
 #include "fair_mutex.hpp"
+#include "fair_shared_mutex.hpp"
 #include "alternate_mutex.hpp"
 #include "alternate_shared_mutex.hpp"
 #include "yamc_shared_lock.hpp"
@@ -39,6 +40,7 @@ using NormalMutexTypes = ::testing::Types<
   yamc::checked::timed_mutex,
   yamc::fair::mutex,
   yamc::fair::timed_mutex,
+  yamc::fair::shared_mutex,
   yamc::alternate::shared_mutex
 >;
 

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -9,6 +9,7 @@
 #include "checked_mutex.hpp"
 #include "checked_shared_mutex.hpp"
 #include "fair_mutex.hpp"
+#include "fair_shared_mutex.hpp"
 #include "alternate_mutex.hpp"
 #include "alternate_shared_mutex.hpp"
 #include "yamc_testutil.hpp"
@@ -155,13 +156,15 @@ int main()
   test_requirements<yamc::checked::recursive_mutex>();
   test_requirements_timed<yamc::checked::timed_mutex>();
   test_requirements_timed<yamc::checked::recursive_timed_mutex>();
-  test_requirements<yamc::checked::shared_mutex>();
-  test_requirements_timed<yamc::checked::shared_timed_mutex>();
+  test_requirements_shared<yamc::checked::shared_mutex>();
+  test_requirements_shared_timed<yamc::checked::shared_timed_mutex>();
 
   test_requirements<yamc::fair::mutex>();
   test_requirements<yamc::fair::recursive_mutex>();
   test_requirements_timed<yamc::fair::timed_mutex>();
   test_requirements_timed<yamc::fair::recursive_timed_mutex>();
+  test_requirements_shared<yamc::fair::shared_mutex>();
+  test_requirements_shared_timed<yamc::fair::shared_timed_mutex>();
 
   test_requirements<yamc::alternate::recursive_mutex>();
   test_requirements_timed<yamc::alternate::timed_mutex>();

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -64,18 +64,8 @@ void test_requirements_timed()
 template <typename SharedMutex>
 void test_requirements_shared()
 {
+  test_requirements<SharedMutex>();
   SharedMutex mtx;
-  // SharedMutex::lock(), unlock()
-  {
-    std::lock_guard<SharedMutex> lk(mtx);
-  }
-  {
-    std::unique_lock<SharedMutex> lk(mtx);
-  }
-  // SharedMutex::try_lock()
-  {
-    std::unique_lock<SharedMutex> lk(mtx, std::try_to_lock);
-  }
   // SharedMutex::lock_shared(), unlock_shared()
   mtx.lock_shared();
   mtx.unlock_shared();
@@ -90,27 +80,8 @@ template <typename SharedTimedMutex>
 void test_requirements_shared_timed()
 {
   test_requirements_shared<SharedTimedMutex>();
+  test_requirements_timed<SharedTimedMutex>();
   SharedTimedMutex mtx;
-  // SharedTimedMutex::try_lock_for()
-  if (mtx.try_lock_for(std::chrono::nanoseconds(1))) {
-    mtx.unlock();
-  }
-  if (mtx.try_lock_for(std::chrono::seconds(1))) {
-    mtx.unlock();
-  }
-  if (mtx.try_lock_for(std::chrono::hours(1))) {  // shall immediately return 'true'...
-    mtx.unlock();
-  }
-  // SharedTimedMutex::try_lock_until()
-  if (mtx.try_lock_until(std::chrono::system_clock::now())) {
-    mtx.unlock();
-  }
-  if (mtx.try_lock_until(std::chrono::steady_clock::now())) {
-    mtx.unlock();
-  }
-  if (mtx.try_lock_until(std::chrono::high_resolution_clock::now())) {
-    mtx.unlock();
-  }
   // SharedTimedMutex::try_lock_shared_for()
   if (mtx.try_lock_shared_for(std::chrono::nanoseconds(1))) {
     mtx.unlock_shared();

--- a/tests/dump_typeinfo.cpp
+++ b/tests/dump_typeinfo.cpp
@@ -11,6 +11,7 @@
 #include "checked_mutex.hpp"
 #include "checked_shared_mutex.hpp"
 #include "fair_mutex.hpp"
+#include "fair_shared_mutex.hpp"
 #include "alternate_mutex.hpp"
 #include "alternate_shared_mutex.hpp"
 
@@ -51,6 +52,8 @@ int main()
   DUMP(yamc::fair::recursive_mutex);
   DUMP(yamc::fair::timed_mutex);
   DUMP(yamc::fair::recursive_timed_mutex);
+  DUMP(yamc::fair::shared_mutex);
+  DUMP(yamc::fair::shared_timed_mutex);
 
   DUMP(yamc::alternate::recursive_mutex);
   DUMP(yamc::alternate::timed_mutex);

--- a/tests/fairness_test.cpp
+++ b/tests/fairness_test.cpp
@@ -154,6 +154,7 @@ TYPED_TEST(FairTimedMutexTest, FifoTryLockFor)
       ph.advance(1);  // p2
       EXPECT_FALSE(mtx.try_lock_for(TEST_TICKS * 2));
       step += 2;
+      TRACE("STEP:1-2(timeout)");
       ph.advance(1);  // p3
       EXPECT_TRUE(mtx.try_lock_for(TEST_NOT_TIMEOUT));
       EXPECT_STEP(5)
@@ -211,6 +212,7 @@ TYPED_TEST(FairTimedMutexTest, FifoTryLockUntil)
       ph.advance(1);  // p2
       EXPECT_FALSE(mtx.try_lock_until(Clock::now() + TEST_TICKS * 2));
       step += 2;
+      TRACE("STEP:1-2(timeout)");
       ph.advance(1);  // p3
       EXPECT_TRUE(mtx.try_lock_until(Clock::now() + TEST_NOT_TIMEOUT));
       EXPECT_STEP(5)
@@ -245,12 +247,12 @@ TYPED_TEST_CASE(FairSharedMutexTest, FairSharedMutexTypes);
 // T0/W: L=a=1=a=2=a=3=a=a=U................
 //         |   |   |   |  \|--\
 // T1/R: ..w.s-|---|---|---S=4=w=6=V........
-//         |  /   /   /    |    \  |
-// T2/R: ..a.w.s-/---/-----S=5=V.a.|.s-S=9=V
-//         | |  /   /              |   |
-// T3/W: ..a.a.w.l-/---------------L=7=U....
-//         | | |  /                    |
-// T4/R: ..a.a.a.w.s-------------------S=8=V
+//         |   |   |   |   |    \  |
+// T2/R: ..a...w.s-|---|---S=5=V.a.|.s-S=9=V
+//         |  /    |   |           |   |
+// T3/W: ..a.a.....w.l-|-----------L=7=U....
+//         | |    /    |               |
+// T4/R: ..a.a...a.....w.s-------------S=8=V
 //
 //   l/L=lock(request/acquired), U=unlock()
 //   s/S=lock_shared(request/acquired), V=unlock_shared()
@@ -259,7 +261,7 @@ TYPED_TEST_CASE(FairSharedMutexTest, FairSharedMutexTypes);
 TYPED_TEST(FairSharedMutexTest, PhaseFifoSched)
 {
   yamc::test::phaser phaser(5);
-  int step = 0;
+  std::atomic<int> step = {0};
   TypeParam mtx;
   yamc::test::stopwatch<> sw;
   yamc::test::task_runner(5, [&](std::size_t id) {
@@ -316,4 +318,285 @@ TYPED_TEST(FairSharedMutexTest, PhaseFifoSched)
     }
   });
   ASSERT_LE(TEST_TICKS * 7, sw.elapsed());
+}
+
+
+// phase-fair RW lock scheduling try_lock_for() timeout
+//
+// T0/W: T=a=1=a=2=a=3=a=a=U..........
+//         |   |   |   |  \|----\
+// T1/R: ..w.s-|---|---|---S=====w=7=V
+//         |   |   |   |   |     |
+// T2/R: ..a...w.s-|---|---S=6=V.a....
+//         |  /    |   |         |
+// T3/W: ..a.a.....w.t-|-4---5-*.a....
+//         | |    /    |       | |
+// T4/R: ..a.a...a.....w.s-----S=w~8=V
+//
+//   t/T=try_lock_for(request/acquired), U=unlock(), *=timeout
+//   s/S=lock_shared(request/acquired), V=unlock_shared()
+//   a=phase advance, w=phase await
+//
+TEST(FairSharedTimedMutexTest, PhaseFifoTryLockFor)
+{
+  yamc::test::phaser phaser(5);
+  std::atomic<int> step = {0};
+  yamc::fair::shared_timed_mutex mtx;
+  yamc::test::stopwatch<> sw;
+  yamc::test::task_runner(5, [&](std::size_t id) {
+    auto ph = phaser.get(id);
+    switch (id) {
+    case 0:
+      EXPECT_TRUE(mtx.try_lock_for(TEST_NOT_TIMEOUT));
+      ph.advance(1);  // p1
+      EXPECT_STEP(1);
+      ph.advance(1);  // p2
+      EXPECT_STEP(2);
+      ph.advance(1);  // p3
+      EXPECT_STEP(3);
+      ph.advance(2);  // p4-5
+      mtx.unlock();
+      break;
+    case 1:
+      ph.await();     // p1
+      ph.advance(3);  // p2-4
+      mtx.lock_shared();
+      ph.await();     // p5
+      EXPECT_STEP_RANGE(7, 8);
+      mtx.unlock_shared();
+      break;
+    case 2:
+      ph.advance(1);  // p1
+      ph.await();     // p2
+      ph.advance(2);  // p3-4
+      mtx.lock_shared();
+      EXPECT_STEP_RANGE(4, 6);
+      mtx.unlock_shared();
+      ph.advance(1);  // p5
+      break;
+    case 3:
+      ph.advance(2);  // p1-2
+      ph.await();     // p3
+      ph.advance(1);  // p4
+      EXPECT_FALSE(mtx.try_lock_for(TEST_TICKS * 2));
+      step += 2;
+      TRACE("STEP4-5(timeout)");
+      ph.advance(1);  // p5
+      break;
+    case 4:
+      ph.advance(3);  // p1-3
+      ph.await();     // p4
+      mtx.lock_shared();
+      ph.await();     // p5
+      EXPECT_STEP_RANGE(7, 8);
+      mtx.unlock_shared();
+      break;
+    }
+  });
+  ASSERT_LE(TEST_TICKS * 5, sw.elapsed());
+}
+
+// phase-fair RW lock scheduling try_lock_until() timeout
+//
+// T0/W: T=a=1=a=2=a=3=a=a=U..........
+//         |   |   |   |  \|----\
+// T1/R: ..w.s-|---|---|---S=====w=7=V
+//         |   |   |   |   |     |
+// T2/R: ..a...w.s-|---|---S=6=V.a....
+//         |  /    |   |         |
+// T3/W: ..a.a.....w.t-|-4---5-*.a....
+//         | |    /    |       | |
+// T4/R: ..a.a...a.....w.s-----S=w~8=V
+//
+//   t/T=try_lock_until(request/acquired), U=unlock(), *=timeout
+//   s/S=lock_shared(request/acquired), V=unlock_shared()
+//   a=phase advance, w=phase await
+//
+TEST(FairSharedTimedMutexTest, PhaseFifoTryLockUntil)
+{
+  yamc::test::phaser phaser(5);
+  std::atomic<int> step = {0};
+  yamc::fair::shared_timed_mutex mtx;
+  using Clock = std::chrono::steady_clock;
+  yamc::test::stopwatch<> sw;
+  yamc::test::task_runner(5, [&](std::size_t id) {
+    auto ph = phaser.get(id);
+    switch (id) {
+    case 0:
+      EXPECT_TRUE(mtx.try_lock_until(Clock::now() + TEST_NOT_TIMEOUT));
+      ph.advance(1);  // p1
+      EXPECT_STEP(1);
+      ph.advance(1);  // p2
+      EXPECT_STEP(2);
+      ph.advance(1);  // p3
+      EXPECT_STEP(3);
+      ph.advance(2);  // p4-5
+      mtx.unlock();
+      break;
+    case 1:
+      ph.await();     // p1
+      ph.advance(3);  // p2-4
+      mtx.lock_shared();
+      ph.await();     // p5
+      EXPECT_STEP_RANGE(7, 8);
+      mtx.unlock_shared();
+      break;
+    case 2:
+      ph.advance(1);  // p1
+      ph.await();     // p2
+      ph.advance(2);  // p3-4
+      mtx.lock_shared();
+      EXPECT_STEP_RANGE(4, 6);
+      mtx.unlock_shared();
+      ph.advance(1);  // p5
+      break;
+    case 3:
+      ph.advance(2);  // p1-2
+      ph.await();     // p3
+      ph.advance(1);  // p4
+      EXPECT_FALSE(mtx.try_lock_until(Clock::now() + TEST_TICKS * 2));
+      step += 2;
+      TRACE("STEP4-5(timeout)");
+      ph.advance(1);  // p5
+      break;
+    case 4:
+      ph.advance(3);  // p1-3
+      ph.await();     // p4
+      mtx.lock_shared();
+      ph.await();     // p5
+      EXPECT_STEP_RANGE(7, 8);
+      mtx.unlock_shared();
+      break;
+    }
+  });
+  ASSERT_LE(TEST_TICKS * 5, sw.elapsed());
+}
+
+// phase-fair RW lock scheduling try_lock_shared_for() timeout
+//
+// T0/W: L=a=1=a=====a=w=5=U........
+//         |  /      | |   |
+// T1/R: ..w.a.s-2-*.a.a...|........
+//         |  \     / /    |
+// T2/W: ..a...w.3.a.a.l---L=6=U....
+//         |   |   |  \        |
+// T3/R: ..a...a...w.4.a.s-----S=7=V
+//
+//   l/L=lock(request/acquired), U=unlock()
+//   s/S=try_lock_shared_for(request/acquired)
+//   V=unlock_shared(), *=timeout
+//   a=phase advance, w=phase await
+//
+TEST(FairSharedTimedMutexTest, PhaseFifoTryLockSharedFor)
+{
+  yamc::test::phaser phaser(4);
+  std::atomic<int> step = {0};
+  yamc::fair::shared_timed_mutex mtx;
+  yamc::test::stopwatch<> sw;
+  yamc::test::task_runner(4, [&](std::size_t id) {
+    auto ph = phaser.get(id);
+    switch (id) {
+    case 0:
+      mtx.lock();
+      ph.advance(1);  // p1
+      EXPECT_STEP(1);
+      ph.advance(2);  // p2-3
+      ph.await() ;    // p4
+      EXPECT_STEP(5);
+      mtx.unlock();
+      break;
+    case 1:
+      ph.await();     // p1
+      ph.advance(1);  // p2
+      EXPECT_FALSE(mtx.try_lock_shared_for(TEST_TICKS));
+      step += 1;
+      TRACE("STEP:2(timeout)");
+      ph.advance(2);  // p3-4
+      break;
+    case 2:
+      ph.advance(1);  // p1
+      ph.await();     // p2
+      EXPECT_STEP_RANGE(2, 3);
+      ph.advance(2);  // p3-4
+      mtx.lock();
+      EXPECT_STEP(6);
+      mtx.unlock();
+      break;
+    case 3:
+      ph.advance(2);  // p1-2
+      ph.await();     // p3
+      EXPECT_STEP(4);
+      ph.advance(1);  // p4
+      EXPECT_TRUE(mtx.try_lock_shared_for(TEST_NOT_TIMEOUT));
+      EXPECT_STEP(7);
+      mtx.unlock_shared();
+      break;
+    }
+  });
+  ASSERT_LE(TEST_TICKS * 6, sw.elapsed());
+}
+
+// phase-fair RW lock scheduling try_lock_shared_until() timeout
+//
+// T0/W: L=a=1=a=====a=w=5=U........
+//         |  /      | |   |
+// T1/R: ..w.a.s-2-*.a.a...|........
+//         |  \     / /    |
+// T2/W: ..a...w.3.a.a.l---L=6=U....
+//         |   |   |  \        |
+// T3/R: ..a...a...w.4.a.s-----S=7=V
+//
+//   l/L=lock(request/acquired), U=unlock()
+//   s/S=try_lock_shared_until(request/acquired)
+//   V=unlock_shared(), *=timeout
+//   a=phase advance, w=phase await
+//
+TEST(FairSharedTimedMutexTest, PhaseFifoTryLockSharedUntil)
+{
+  yamc::test::phaser phaser(4);
+  std::atomic<int> step = {0};
+  yamc::fair::shared_timed_mutex mtx;
+  using Clock = std::chrono::steady_clock;
+  yamc::test::stopwatch<> sw;
+  yamc::test::task_runner(4, [&](std::size_t id) {
+    auto ph = phaser.get(id);
+    switch (id) {
+    case 0:
+      mtx.lock();
+      ph.advance(1);  // p1
+      EXPECT_STEP(1);
+      ph.advance(2);  // p2-3
+      ph.await() ;    // p4
+      EXPECT_STEP(5);
+      mtx.unlock();
+      break;
+    case 1:
+      ph.await();     // p1
+      ph.advance(1);  // p2
+      EXPECT_FALSE(mtx.try_lock_shared_until(Clock::now() + TEST_TICKS));
+      step += 1;
+      TRACE("STEP:2(timeout)");
+      ph.advance(2);  // p3-4
+      break;
+    case 2:
+      ph.advance(1);  // p1
+      ph.await();     // p2
+      EXPECT_STEP_RANGE(2, 3);
+      ph.advance(2);  // p3-4
+      mtx.lock();
+      EXPECT_STEP(6);
+      mtx.unlock();
+      break;
+    case 3:
+      ph.advance(2);  // p1-2
+      ph.await();     // p3
+      EXPECT_STEP(4);
+      ph.advance(1);  // p4
+      EXPECT_TRUE(mtx.try_lock_shared_until(Clock::now() + TEST_NOT_TIMEOUT));
+      EXPECT_STEP(7);
+      mtx.unlock_shared();
+      break;
+    }
+  });
+  ASSERT_LE(TEST_TICKS * 6, sw.elapsed());
 }

--- a/tests/fairness_test.cpp
+++ b/tests/fairness_test.cpp
@@ -1,6 +1,7 @@
 /*
  * fairness_test.cpp
  */
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <mutex>

--- a/tests/rwlock_test.cpp
+++ b/tests/rwlock_test.cpp
@@ -8,6 +8,7 @@
 #include <thread>
 #include "gtest/gtest.h"
 #include "checked_shared_mutex.hpp"
+#include "fair_shared_mutex.hpp"
 #include "alternate_shared_mutex.hpp"
 #include "yamc_shared_lock.hpp"
 #include "yamc_testutil.hpp"
@@ -41,6 +42,8 @@ std::mutex g_guard;
 using SharedMutexTypes = ::testing::Types<
   yamc::checked::shared_mutex,
   yamc::checked::shared_timed_mutex,
+  yamc::fair::shared_mutex,
+  yamc::fair::shared_timed_mutex,
   yamc::alternate::basic_shared_mutex<yamc::rwlock::ReaderPrefer>,
   yamc::alternate::basic_shared_mutex<yamc::rwlock::WriterPrefer>,
   yamc::alternate::basic_shared_timed_mutex<yamc::rwlock::ReaderPrefer>,
@@ -218,6 +221,7 @@ TYPED_TEST(SharedMutexTest, TryLockSharedFail)
 
 using SharedTimedMutexTypes = ::testing::Types<
   yamc::checked::shared_timed_mutex,
+  yamc::fair::shared_timed_mutex,
   yamc::alternate::basic_shared_timed_mutex<yamc::rwlock::ReaderPrefer>,
   yamc::alternate::basic_shared_timed_mutex<yamc::rwlock::WriterPrefer>
 >;


### PR DESCRIPTION
add `shared_(timed_)mutex` with phase-fair readers-writer locking algorithm. implementation is same strategy with #7.

- [x] implement `yamc::fair::shared_mutex` 3d14e571a1935d4f1dc6f256f872e25c2a8d9237
- [x] implement `yamc::fair::shared_timed_mutex` 3d14e571a1935d4f1dc6f256f872e25c2a8d9237
- [x] add testcase for phase-fair R/W-locking ba348a075533ade9ce7c2788e981359ffc086422
- [x] add testcase for try_lock timeout and subsequent scheduling a8d72f064beb418dc76a4cfb789f20e362ca7cbd, 9670db496604fc0b6bbfc168ce84fc1145b2e8c0
- [x] update README 69ded0e68f122ef38e61d82e75dd6ebb005c801d
