### PR TITLE
add phase-fairness RW lock scheduling

### DIFF
--- a/include/fair_shared_mutex.hpp
+++ b/include/fair_shared_mutex.hpp
@@ -3,7 +3,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2017 yohhoy
+ * Copyright (c) 2018 yohhoy
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,18 +32,58 @@
 #include <thread>
 
 
+/// default shared_mutex rwlock fairness policy
+#ifndef YAMC_RWLOCK_FAIRNESS_DEFAULT
+#define YAMC_RWLOCK_FAIRNESS_DEFAULT yamc::rwlock::TaskFairness
+#endif
+
+
+#ifndef YAMC_DEBUG_TRACING
+#define YAMC_DEBUG_TRACING 0
+#endif
+
+#if YAMC_DEBUG_TRACING
+#include <cstdio>
+#define YAMC_DEBUG_TRACE(...)   std::printf(__VA_ARGS__)
+#define YAMC_DEBUG_DUMPQ(msg_)  wq_dump(msg_)
+#else
+#define YAMC_DEBUG_TRACE(...)   (void)0
+#define YAMC_DEBUG_DUMPQ(msg_)  (void)0
+#endif
+
+
 namespace yamc {
 
 /*
- * phase-fairness (FIFO locking) shared mutex
+ * readers-writer locking fairness policy for basic_shared_(timed)_mutex<RwLockFairness>
  *
- * - yamc::fair::shared_mutex
- * - yamc::fair::shared_timed_mutex
+ * - yamc::rwlock::TaskFairness
+ * - yamc::rwlock::PhaseFairness
+ */
+namespace rwlock {
+
+struct TaskFairness {
+  static constexpr bool phased = false;
+};
+
+struct PhaseFairness {
+  static constexpr bool phased = true;
+};
+
+} // namespace rwlock
+
+
+/*
+ * fairness (FIFO locking) shared mutex
+ *
+ * - yamc::fair::basic_shared_mutex<RwLockFairness>
+ * - yamc::fair::basic_shared_timed_mutex<RwLockFairness>
  */
 namespace fair {
 
 namespace detail {
 
+template <typename RwLockFairness>
 class shared_mutex_base {
 protected:
   const static std::size_t node_status_mask = 3;
@@ -65,6 +105,23 @@ protected:
   std::mutex mtx_;
 
 private:
+#if YAMC_DEBUG_TRACING
+  void wq_dump(const char* msg)
+  {
+    YAMC_DEBUG_TRACE("%s [", msg);
+    for (node* p = queue_.next; p != &queue_; p = p->next) {
+      const char* delim = (p->next != &queue_) ? ", " : "";
+      char sym = ((p->status & 1) ? 'S' : 'E') + ((p->status & 2) ? 0 : 'a'-'A');
+      if (p == &locked_) {
+        YAMC_DEBUG_TRACE("L%lu:%c%s", (p->status >> 2), sym, delim);
+      } else {
+        YAMC_DEBUG_TRACE("R:%c%s", sym, delim);
+      }
+    }
+    YAMC_DEBUG_TRACE("]\n");
+  }
+#endif
+
   bool wq_empty()
   {
     return queue_.next == &queue_;
@@ -122,97 +179,138 @@ protected:
 
   void impl_lock(std::unique_lock<std::mutex>& lk)
   {
+    YAMC_DEBUG_DUMPQ(">>lock");
     if (!wq_empty()) {
       node request = {0, 0, 0};  // exclusive-lock
       wq_push_back(&request);
+      YAMC_DEBUG_DUMPQ("  lock/wait");
       while (queue_.next != &request) {
         cv_.wait(lk);
       }
       wq_erase(&request);
     }
     wq_push_locknode(0);
+    YAMC_DEBUG_DUMPQ("<<lock");
   }
 
   bool impl_try_lock()
   {
+    YAMC_DEBUG_DUMPQ(">>try_lock");
     if (!wq_empty()) {
+      YAMC_DEBUG_DUMPQ("<<try_lock/false");
       return false;
     }
     wq_push_locknode(0);
+    YAMC_DEBUG_DUMPQ("<<try_lock/true");
     return true;
   }
 
   void impl_unlock()
   {
+    YAMC_DEBUG_DUMPQ(">>unlock");
     assert(queue_.next == &locked_ && (locked_.status & node_status_mask) == 2);
     wq_pop_locknode();
     if (!wq_empty()) {
       // mark subsequent 'waiting' shared-lock nodes as 'lockable'
-      node* p = queue_.next;
-      while (p != &queue_ && (p->status & node_status_mask) == 1) {
-        p->status |= 2;
-        p = p->next;
+      if (RwLockFairness::phased) {
+        // PhaseFairness: mark all queued shared-lock nodes
+        if ((queue_.next->status & node_status_mask) == 1) {
+          for (node* p = queue_.next; p != &queue_; p = p->next) {
+            if ((p->status & node_status_mask) == 1) {
+              p->status |= 2;
+            }
+          }
+        }
+      } else {
+        // TaskFairness: mark immediately subsequent shared-lock nodes
+        node* p = queue_.next;
+        while (p != &queue_ && (p->status & node_status_mask) == 1) {
+          p->status |= 2;
+          p = p->next;
+        }
       }
     }
     cv_.notify_all();
+    YAMC_DEBUG_DUMPQ("<<unlock");
   }
 
   template<typename Clock, typename Duration>
   bool impl_try_lockwait(std::unique_lock<std::mutex>& lk, const std::chrono::time_point<Clock, Duration>& tp)
   {
+    YAMC_DEBUG_DUMPQ(">>try_lockwait");
     if (!wq_empty()) {
       node request = {0, 0, 0};  // exclusive-lock
       wq_push_back(&request);
+      YAMC_DEBUG_DUMPQ("  try_lockwait/wait");
       while (queue_.next != &request) {
         if (cv_.wait_until(lk, tp) == std::cv_status::timeout) {
           if (queue_.next == &request)  // re-check predicate
             break;
           if (request.prev == &locked_ && (locked_.status & node_status_mask) == 3) {
             //
-            // Phase-marging: If previous node represents current shared-lock,
+            // When exclusive-lock are timeouted and previous shared-lock own lock,
             // mark subsequent 'waiting' shared-lock nodes as 'lockable'.
             //
-            node* p = request.next;
-            while (p != &queue_ && (p->status & node_status_mask) == 1) {
-              p->status |= 2;
-              p = p->next;
+            if (RwLockFairness::phased) {
+              // PhaseFairness: mark all queued shared-lock nodes
+              for (node* p = request.next; p != &queue_; p = p->next) {
+                if ((p->status & node_status_mask) == 1) {
+                  p->status |= 2;
+                }
+              }
+            } else {
+              // TaskFairness: mark immediately subsequent shared-lock nodes group
+              node* p = request.next;
+              while (p != &queue_ && (p->status & node_status_mask) == 1) {
+                p->status |= 2;
+                p = p->next;
+              }
             }
             cv_.notify_all();
           }
           wq_erase(&request);
+          YAMC_DEBUG_DUMPQ("<<try_lockwait/false");
           return false;
         }
       }
       wq_erase(&request);
     }
     wq_push_locknode(0);
+    YAMC_DEBUG_DUMPQ("<<try_lockwait/true");
     return true;
   }
 
   void impl_lock_shared(std::unique_lock<std::mutex>& lk)
   {
+    YAMC_DEBUG_DUMPQ(">>lock_shared");
     if (!wq_shared_lockable()) {
       node request = {1, 0, 0};  // shared-lock
       wq_push_back(&request);
+      YAMC_DEBUG_DUMPQ("  lock_shared/wait");
       while (request.status != 3) {
         cv_.wait(lk);
       }
       wq_erase(&request);
     }
     wq_push_locknode(1);
+    YAMC_DEBUG_DUMPQ("<<lock_shared");
   }
 
   bool impl_try_lock_shared()
   {
+    YAMC_DEBUG_DUMPQ(">>try_lock_shared");
     if (!wq_shared_lockable()) {
+      YAMC_DEBUG_DUMPQ("<<try_lock_shared/false");
       return false;
     }
     wq_push_locknode(1);
+    YAMC_DEBUG_DUMPQ("<<try_lock_shared/true");
     return true;
   }
 
   void impl_unlock_shared()
   {
+    YAMC_DEBUG_DUMPQ(">>unlock_shared");
     assert(queue_.next == &locked_ && (locked_.status & node_status_mask) == 3);
     locked_.status -= node_nthread_inc;
     if (locked_.status < node_nthread_inc) {
@@ -220,25 +318,30 @@ protected:
       wq_pop_locknode();
       cv_.notify_all();
     }
+    YAMC_DEBUG_DUMPQ("<<unlock_shared");
   }
 
   template<typename Clock, typename Duration>
   bool impl_try_lockwait_shared(std::unique_lock<std::mutex>& lk, const std::chrono::time_point<Clock, Duration>& tp)
   {
+    YAMC_DEBUG_DUMPQ(">>try_lockwait_shared");
     if (!wq_shared_lockable()) {
       node request = {1, 0, 0};  // shared-lock
       wq_push_back(&request);
+      YAMC_DEBUG_DUMPQ("  try_lockwait_shared/wait");
       while (request.status != 3) {
         if (cv_.wait_until(lk, tp) == std::cv_status::timeout) {
           if (request.status == 3)  // re-check predicate
             break;
           wq_erase(&request);
+          YAMC_DEBUG_DUMPQ("<<try_lockwait_shared/false");
           return false;
         }
       }
       wq_erase(&request);
     }
     wq_push_locknode(1);
+    YAMC_DEBUG_DUMPQ("<<try_lockwait_shared/true");
     return true;
   }
 };
@@ -246,15 +349,17 @@ protected:
 } // namespace detail
 
 
-class shared_mutex : private detail::shared_mutex_base {
-  using base = detail::shared_mutex_base;
+template <typename RwLockFairness>
+class basic_shared_mutex : private detail::shared_mutex_base<RwLockFairness> {
+  using base = detail::shared_mutex_base<RwLockFairness>;
+  using base::mtx_;
 
 public:
-  shared_mutex() = default;
-  ~shared_mutex() = default;
+  basic_shared_mutex() = default;
+  ~basic_shared_mutex() = default;
 
-  shared_mutex(const shared_mutex&) = delete;
-  shared_mutex& operator=(const shared_mutex&) = delete;
+  basic_shared_mutex(const basic_shared_mutex&) = delete;
+  basic_shared_mutex& operator=(const basic_shared_mutex&) = delete;
 
   void lock()
   {
@@ -293,16 +398,20 @@ public:
   }
 };
 
+using shared_mutex = basic_shared_mutex<YAMC_RWLOCK_FAIRNESS_DEFAULT>;
 
-class shared_timed_mutex : private detail::shared_mutex_base {
-  using base = detail::shared_mutex_base;
+
+template <typename RwLockFairness>
+class basic_shared_timed_mutex : private detail::shared_mutex_base<RwLockFairness> {
+  using base = detail::shared_mutex_base<RwLockFairness>;
+  using base::mtx_;
 
 public:
-  shared_timed_mutex() = default;
-  ~shared_timed_mutex() = default;
+  basic_shared_timed_mutex() = default;
+  ~basic_shared_timed_mutex() = default;
 
-  shared_timed_mutex(const shared_timed_mutex&) = delete;
-  shared_timed_mutex& operator=(const shared_timed_mutex&) = delete;
+  basic_shared_timed_mutex(const basic_shared_timed_mutex&) = delete;
+  basic_shared_timed_mutex& operator=(const basic_shared_timed_mutex&) = delete;
 
   void lock()
   {
@@ -370,6 +479,9 @@ public:
     return base::impl_try_lockwait_shared(lk, tp);
   }
 };
+
+using shared_timed_mutex = basic_shared_timed_mutex<YAMC_RWLOCK_FAIRNESS_DEFAULT>;
+
 
 } // namespace fair
 } // namespace yamc

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -107,7 +107,6 @@ void test_requirements_shared_timed()
 
 int main()
 {
-
   test_requirements<yamc::spin::mutex>();
   test_requirements<yamc::spin_weak::mutex>();
   test_requirements<yamc::spin_ttas::mutex>();
@@ -133,8 +132,14 @@ int main()
   test_requirements<yamc::fair::recursive_mutex>();
   test_requirements_timed<yamc::fair::timed_mutex>();
   test_requirements_timed<yamc::fair::recursive_timed_mutex>();
+
   test_requirements_shared<yamc::fair::shared_mutex>();
   test_requirements_shared_timed<yamc::fair::shared_timed_mutex>();
+  // shared_(timed_)muetx with yamc::rwlock::* policy
+  test_requirements_shared<yamc::fair::basic_shared_mutex<yamc::rwlock::TaskFairness>>();
+  test_requirements_shared<yamc::fair::basic_shared_mutex<yamc::rwlock::PhaseFairness>>();
+  test_requirements_shared_timed<yamc::fair::basic_shared_timed_mutex<yamc::rwlock::TaskFairness>>();
+  test_requirements_shared_timed<yamc::fair::basic_shared_timed_mutex<yamc::rwlock::PhaseFairness>>();
 
   test_requirements<yamc::alternate::mutex>();
   test_requirements<yamc::alternate::recursive_mutex>();

--- a/tests/dump_typeinfo.cpp
+++ b/tests/dump_typeinfo.cpp
@@ -52,8 +52,13 @@ int main()
   DUMP(yamc::fair::recursive_mutex);
   DUMP(yamc::fair::timed_mutex);
   DUMP(yamc::fair::recursive_timed_mutex);
+
   DUMP(yamc::fair::shared_mutex);
   DUMP(yamc::fair::shared_timed_mutex);
+  DUMP(yamc::fair::basic_shared_mutex<yamc::rwlock::TaskFairness>);
+  DUMP(yamc::fair::basic_shared_mutex<yamc::rwlock::PhaseFairness>);
+  DUMP(yamc::fair::basic_shared_timed_mutex<yamc::rwlock::TaskFairness>);
+  DUMP(yamc::fair::basic_shared_timed_mutex<yamc::rwlock::PhaseFairness>);
 
   DUMP(yamc::alternate::mutex);
   DUMP(yamc::alternate::recursive_mutex);

--- a/tests/perf_rwlock.cpp
+++ b/tests/perf_rwlock.cpp
@@ -213,11 +213,14 @@ int main()
   unsigned nthread = 10;
   using reader_prefer_shared_mutex = yamc::alternate::basic_shared_mutex<yamc::rwlock::ReaderPrefer>;
   using writer_prefer_shared_mutex = yamc::alternate::basic_shared_mutex<yamc::rwlock::WriterPrefer>;
+  using task_fairness_shared_mutex  = yamc::fair::basic_shared_mutex<yamc::rwlock::TaskFairness>;
+  using phase_fairness_shared_mutex = yamc::fair::basic_shared_mutex<yamc::rwlock::PhaseFairness>;
 
   perf_lock<std::mutex>       ("StdMutex", nthread);
   perf_lock<yamc::fair::mutex>("FifoMutex", nthread);
 
   perf_rwlock<reader_prefer_shared_mutex>("ReaderPrefer", nthread);
   perf_rwlock<writer_prefer_shared_mutex>("WriterPrefer", nthread);
-  perf_rwlock<yamc::fair::shared_mutex> ("PhaseFair", nthread);
+  perf_rwlock<task_fairness_shared_mutex> ("TaskFair", nthread);
+  perf_rwlock<phase_fairness_shared_mutex>("PhaseFair", nthread);
 }

--- a/tests/perf_rwlock.sh
+++ b/tests/perf_rwlock.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
 DATFILE="perf_rwlock.dat"
-PNGFILE="perf_rwlock.png"
-
 echo "input: ${DATFILE}"
+
+if [ ! -f ${DATFILE} ]; then
+  echo "file not found.\nrun \"perf_rwlock > ${DATFILE}\""
+  exit 1
+fi
+
+
+PNGFILE="perf_rwlock.png"
+echo "output: ${PNGFILE}"
 gnuplot << EOT
 set terminal png medium
 set output "${PNGFILE}"
 
-set title "rwlock contention"
+set title "rwlock throughput"
 set xlabel "writer threads"
 set ylabel "ops/sec/thread"
 set xrange [0.5:9.5]
@@ -21,9 +28,50 @@ plot "${DATFILE}" index 2 using 1:3   with lines     lt 1 title "ReaderPerfer/Wr
      "${DATFILE}" index 3 using 1:3:4 with errorbars lt 3 notitle, \
      "${DATFILE}" index 3 using 1:7   with lines     lt 4 title "WriterPerfer/ReadLock", \
      "${DATFILE}" index 3 using 1:7:8 with errorbars lt 4 notitle, \
-     "${DATFILE}" index 4 using 1:3   with lines     lt 5 title "PhaseFair/WriteLock", \
+     "${DATFILE}" index 4 using 1:3   with lines     lt 5 title "TaskFair/WriteLock", \
      "${DATFILE}" index 4 using 1:3:4 with errorbars lt 5 notitle, \
-     "${DATFILE}" index 4 using 1:7   with lines     lt 6 title "PhaseFair/ReadLock", \
-     "${DATFILE}" index 4 using 1:7:8 with errorbars lt 6 notitle,
+     "${DATFILE}" index 4 using 1:7   with lines     lt 6 title "TaskFair/ReadLock", \
+     "${DATFILE}" index 4 using 1:7:8 with errorbars lt 6 notitle, \
+     "${DATFILE}" index 5 using 1:3   with lines     lt 7 title "PhaseFair/WriteLock", \
+     "${DATFILE}" index 5 using 1:3:4 with errorbars lt 7 notitle, \
+     "${DATFILE}" index 5 using 1:7   with lines     lt 8 title "PhaseFair/ReadLock", \
+     "${DATFILE}" index 5 using 1:7:8 with errorbars lt 8 notitle,
 EOT
+
+
+PNGFILE="perf_rwlock-unfair.png"
 echo "output: ${PNGFILE}"
+gnuplot << EOT
+set terminal png medium
+set output "${PNGFILE}"
+
+set title "rwlock throughput"
+set xlabel "writer threads"
+set ylabel "ops/sec/thread"
+set xrange [0.5:9.5]
+set yrange [0:]
+
+plot "${DATFILE}" index 2 using 1:3 with linespoints lt 1 title "ReaderPerfer/WriteLock", \
+     "${DATFILE}" index 2 using 1:7 with linespoints lt 2 title "ReaderPerfer/ReadLock", \
+     "${DATFILE}" index 3 using 1:3 with linespoints lt 3 title "WriterPerfer/WriteLock", \
+     "${DATFILE}" index 3 using 1:7 with linespoints lt 4 title "WriterPerfer/ReadLock",
+EOT
+
+
+PNGFILE="perf_rwlock-fair.png"
+echo "output: ${PNGFILE}"
+gnuplot << EOT
+set terminal png medium
+set output "${PNGFILE}"
+
+set title "rwlock throughput"
+set xlabel "writer threads"
+set ylabel "ops/sec/thread"
+set xrange [0.5:9.5]
+set yrange [0:]
+
+plot "${DATFILE}" index 4 using 1:3 with linespoints lt 5 title "TaskFair/WriteLock", \
+     "${DATFILE}" index 4 using 1:7 with linespoints lt 6 title "TaskFair/ReadLock", \
+     "${DATFILE}" index 5 using 1:3 with linespoints lt 7 title "PhaseFair/WriteLock", \
+     "${DATFILE}" index 5 using 1:7 with linespoints lt 8 title "PhaseFair/ReadLock",
+EOT

--- a/tests/rwlock_test.cpp
+++ b/tests/rwlock_test.cpp
@@ -42,8 +42,10 @@ std::mutex g_guard;
 using SharedMutexTypes = ::testing::Types<
   yamc::checked::shared_mutex,
   yamc::checked::shared_timed_mutex,
-  yamc::fair::shared_mutex,
-  yamc::fair::shared_timed_mutex,
+  yamc::fair::basic_shared_mutex<yamc::rwlock::TaskFairness>,
+  yamc::fair::basic_shared_mutex<yamc::rwlock::PhaseFairness>,
+  yamc::fair::basic_shared_timed_mutex<yamc::rwlock::TaskFairness>,
+  yamc::fair::basic_shared_timed_mutex<yamc::rwlock::PhaseFairness>,
   yamc::alternate::basic_shared_mutex<yamc::rwlock::ReaderPrefer>,
   yamc::alternate::basic_shared_mutex<yamc::rwlock::WriterPrefer>,
   yamc::alternate::basic_shared_timed_mutex<yamc::rwlock::ReaderPrefer>,
@@ -225,7 +227,8 @@ TYPED_TEST(SharedMutexTest, TryLockSharedFail)
 
 using SharedTimedMutexTypes = ::testing::Types<
   yamc::checked::shared_timed_mutex,
-  yamc::fair::shared_timed_mutex,
+  yamc::fair::basic_shared_timed_mutex<yamc::rwlock::TaskFairness>,
+  yamc::fair::basic_shared_timed_mutex<yamc::rwlock::PhaseFairness>,
   yamc::alternate::basic_shared_timed_mutex<yamc::rwlock::ReaderPrefer>,
   yamc::alternate::basic_shared_timed_mutex<yamc::rwlock::WriterPrefer>
 >;


### PR DESCRIPTION
- [x] add phase-fairness scheduling policy
- [x] add phased shared-lock acquisition testcase (a0e897b2ba5c524a2c386e9598a66398070823a4)
- [x] add no writer starvation testcast (bb5402de1004a23e55027d9f40ad2edb9888437a)
- [x] update `tests/perf_rwlock` (ef43ad82fc0f6256e1136bdae3440789eb442631)
- [x] update README (cd24036f6c75e95ab87a18f5071dc54b7d61051c)