### PR TITLE
Tweaked the CMakeLists.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
 script:
   - mkdir build
   - cd build
-  - cmake -DCMAKE_CXX_COMPILER=$COMPILER ..
+  - cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_CXX_COMPILER=$COMPILER -DENABLE_TESTING=ON ..
   - make -j2
   - tests/dump_sizeof
   - tests/dump_layout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ endif()
 
 include_directories(include)
 
-if (CB_ENABLE_TESTING)
-	enable_testing()
-	add_subdirectory(tests)
+if (ENABLE_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
 endif()
 
 install(DIRECTORY include/ DESTINATION include/yamc/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,23 @@ cmake_minimum_required(VERSION 3.2)
 
 project(yamc C CXX)
 
-# require C++11
+# Requires C++11
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(ENABLE_TESTING "Enable unit testing." ON)
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic")
-  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-  set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O2")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
 endif()
 
 include_directories(include)
 
-enable_testing()
-add_subdirectory(tests)
+if (CB_ENABLE_TESTING)
+	enable_testing()
+	add_subdirectory(tests)
+endif()
+
+install(DIRECTORY include/ DESTINATION include/yamc/
+    FILES_MATCHING PATTERN "*.hpp")


### PR DESCRIPTION
As per issue #22:

1. Enable option to disable compilation of testing. 
2. Disable explicit configuration of some CXX_FLAGS. 
3. Add install step.

Build types listed [here ](http://www.brianlheim.com/2018/04/09/cmake-cheat-sheet.html)states that -DNDEBUG is already included on release-type builds. I can confirm this with my own testing.